### PR TITLE
Re-defined border reset location

### DIFF
--- a/_objects.buttons.scss
+++ b/_objects.buttons.scss
@@ -54,7 +54,6 @@ $inuit-global-border-box: false !default;
     vertical-align: middle; /* [2] */
     font: inherit; /* [3] */
     text-align: center; /* [4] */
-    border: none; /* [4] */
     margin:  0; /* [4] */
     cursor: pointer; /* [5] */
     overflow: visible; /* [6] */
@@ -63,6 +62,8 @@ $inuit-global-border-box: false !default;
 
     @if($inuit-btn-border-width != 0) {
         border: $inuit-btn-border-width $inuit-btn-border-style $inuit-btn-border-color;
+    } @else {
+        border: none; /* [4] */
     }
 
     @if($inuit-btn-radius != 0) {


### PR DESCRIPTION
The location of the border reset  is re-defined to apply only when no border width is defined. Doing this will result in the output CSS having only one border property being defined instead of two.

Example original:

    .btn {
        display: inline-block;
        /* [1] */
        vertical-align: middle;
        /* [2] */
        font: inherit;
        /* [3] */
        text-align: center;
        /* [4] */
        border: none;
        /* [4] */
        margin: 0;
        /* [4] */
        cursor: pointer;
        /* [5] */
        overflow: visible;
        /* [6] */
        padding: 10px 21px;
        /* [7] */
        background-color: #4a8ec2;
        border: 1px solid #4a8ec2; 
    }

Example fixed:

    .btn {
        display: inline-block;
        /* [1] */
        vertical-align: middle;
        /* [2] */
        font: inherit;
        /* [3] */
        text-align: center;
        /* [4] */
        margin: 0;
        /* [4] */
        cursor: pointer;
        /* [5] */
        overflow: visible;
        /* [6] */
        padding: 10px 21px;
        /* [7] */
        background-color: #4a8ec2;
        border: 1px solid #4a8ec2; 
    }